### PR TITLE
ttlLocal: ttl for local cache entries, independent from remote ttl

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -119,6 +119,10 @@ Returning `undefined` or an `Error` instance in replace of a result object will 
 
 Amount of time, in milliseconds, until cache entry is stale. This value will be passed to the remote cache instance when setting new values into a worker. Defaults to one minute.
 
+### `ttlLocal`
+
+Amount of time, in milliseconds, until local cache entry is stale. This value applies only to local cache entries, and does not get passed to remote cache instances. Defaults to the value of ttl.
+
 ### `minimumRequestsForCache`
 
 Minimum number of requests that must be made before entry can be added to the local cache. Defaults to none.

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -12,6 +12,13 @@ export interface CacheSettings {
   ttl?: number;
 
   /**
+   * Amount of time, in milliseconds, until local cache entry is stale.
+   * This value applies only to local cache entries, and does not get
+   * passed to remote cache instances. Defaults to the value of ttl
+   */
+  ttlLocal?: number;
+
+  /**
    * Minimum number of requests that must be made before entry
    * can be added to the local cache. Defaults to none
    */


### PR DESCRIPTION
- Adds `ttlLocal` configuration to `CacheSettings` interface
- Defaults `ttlLocal` to `ttl`