### PR TITLE
getEntry: Fetching meta information along with a cached value

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -282,7 +282,7 @@ Returns list of valid cache entry values in the cache.
 
 Returns list of valid cache entries in the cache.
 
-### `forEach(iter: (value: ResultType, id: IdentifierType) => void)`
+### `forEach(iter: (value: CachedEntry<IdentifierType, ResultType>, id: IdentifierType) => void)`
 
 Executes the provided function once per each valid id/value pair in the cache.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,6 +15,12 @@ Review the list of supported extensions below for easy configuration of common b
 | [@level-two/kafka](https://www.npmjs.com/package/@level-two/kafka)         | Kafka extension for a message broker only      |
 | [@level-two/memcached](https://www.npmjs.com/package/@level-two/memcached) | Memcached extension for a cache only           |
 
+## Breaking Changes
+
+Starting with version `2.0.0`: Iterable, `peek`, `peekMulti`, `values`, `entries`, `forEach` all return `CachedEntry` wrapped result values instead of the `ResultValue` directly.
+
+Switching to a wrapped `CachedEntry` will allow for current and future expansion on utilities for metric tracking of entries.
+
 ## Usage
 
 ```ts
@@ -178,9 +184,9 @@ Shortcut method for batch fetching a single object. Any error is thrown instead 
 
 Shortcut method for batch fetching a single required object. Any error is thrown instead of returned, and exception is raised if no value is found
 
-### `getMeta(id: IdentifierType)`
+### `getEntry(id: IdentifierType)`
 
-Shortcut method for batch fetching a single meta wrapped entry. Exceptions are returned, not raised
+Shortcut method for batch fetching a single Entry wrapped value. Exceptions are returned, not raised.
 
 ### `getMulti(ids: IdentifierType[])`
 
@@ -196,9 +202,9 @@ Similar to getMulti, fetches list of values for the identifiers provided, but ra
 
 Similar to getMulti, fetches list of values for the identifiers provided, but raises exceptions when values are not found for any id
 
-### `getMetaMulti(ids: IdentifierType[])`
+### `getEntryMulti(ids: IdentifierType[])`
 
-Similar to getMulti, gets a a list of meta wrapped entries for the identifiers provided. The "source" indicates at what point the value was retrieved from (local-cache, remote-cache, or worker)
+Similar to getMulti, gets a a list of Entry wrapped values for the identifiers provided. The "source" indicates at what point the value was retrieved from (local-cache, remote-cache, or worker)
 
 Exceptions are returned, not raised, and use the "error" source key
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -312,6 +312,50 @@ Deletes any expired (past stale) entries from the local cache, as well as any ex
 
 Clears local caches of all entries.
 
+## Entry & CachedEntry
+
+The `Entry` and `CachedEntry` classes represent entry wrapped result values for metric tracking and viewing source of what level the data was fetched from
+
+### `id`
+
+Unique cache identifier
+
+### `createdAt`
+
+Timestamp of when the _local_ cache entry was created
+
+### `source`
+
+Source of where the value was fetched from
+
+### `value`
+
+Value of the cached entry. Optional for `Entry`, required for `CachedEntry`
+
+### `error`
+
+Optional exception that occurred during fetching of value
+
+### `staleAt`
+
+Timestamp in milliseconds of when the cache entry becomes stale (can still be used, just refreshed in the background)
+
+### `expiresAt`
+
+Timestamp in milliseconds of when the cache entry expires (can no longer be used)
+
+### `upsertedAt`
+
+Timestamp in milliseconds of when the cache
+
+### `get isStale()`
+
+Indicates if the entry is stale (can still be used, just past the ttl)
+
+### `get isExpired()`
+
+Indicates if the entry is still usable (past stale threshold)
+
 ## SingleKeyWorker
 
 Cache worker for a single key entry

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -178,6 +178,10 @@ Shortcut method for batch fetching a single object. Any error is thrown instead 
 
 Shortcut method for batch fetching a single required object. Any error is thrown instead of returned, and exception is raised if no value is found
 
+### `getMeta(id: IdentifierType)`
+
+Shortcut method for batch fetching a single meta wrapped entry. Exceptions are returned, not raised
+
 ### `getMulti(ids: IdentifierType[])`
 
 Gets a a list of values for the identifiers provided. First attempts to find values from the local cache, then falls back to remote cache if defined, and finally pulls from the worker process.
@@ -191,6 +195,12 @@ Similar to getMulti, fetches list of values for the identifiers provided, but ra
 ### `getRequiredMulti(ids: IdentifierType[])`
 
 Similar to getMulti, fetches list of values for the identifiers provided, but raises exceptions when values are not found for any id
+
+### `getMetaMulti(ids: IdentifierType[])`
+
+Similar to getMulti, gets a a list of meta wrapped entries for the identifiers provided. The "source" indicates at what point the value was retrieved from (local-cache, remote-cache, or worker)
+
+Exceptions are returned, not raised, and use the "error" source key
 
 ### `stream(ids: IdentifierType[], streamResultCallback: (id: IdentifierType, result: ResultType) => Promise<void>)`
 

--- a/packages/core/benchmark/baseline.ts
+++ b/packages/core/benchmark/baseline.ts
@@ -73,6 +73,17 @@ BATCH_COUNT.forEach((idCount) => {
   });
 });
 
+BATCH_COUNT.forEach((idCount) => {
+  const ids = generateIds(idCount);
+  suite.add(`getEntryMulti ${ids.length} ids`, {
+    defer: true,
+    fn: async (deferred: Benchmark.Deferred) => {
+      await worker.getEntryMulti(ids);
+      deferred.resolve();
+    },
+  });
+});
+
 suite
   .on("cycle", (event: Benchmark.Event) => {
     console.log(String(event.target));

--- a/packages/core/src/CachedEntry.ts
+++ b/packages/core/src/CachedEntry.ts
@@ -1,0 +1,31 @@
+import { Entry, EntryProps } from "./Entry";
+/**
+ * Options for creating an CachedEntry instance
+ */
+export type CachedEntryProps<IdentifierType, ResultType> = Omit<
+  EntryProps<IdentifierType, ResultType>,
+  "value"
+> & {
+  /**
+   * Value of the cached entry
+   */
+  value: ResultType;
+};
+
+/**
+ * Cached entry object with required value
+ */
+export class CachedEntry<IdentifierType, ResultType> extends Entry<
+  IdentifierType,
+  ResultType
+> {
+  /**
+   * Value of the cached entry
+   */
+  public value: ResultType;
+
+  constructor(props: CachedEntryProps<IdentifierType, ResultType>) {
+    super(props);
+    this.value = props.value;
+  }
+}

--- a/packages/core/src/CachedEntry.ts
+++ b/packages/core/src/CachedEntry.ts
@@ -1,4 +1,5 @@
 import { Entry, EntryProps } from "./Entry";
+
 /**
  * Options for creating an CachedEntry instance
  */

--- a/packages/core/src/Entry.ts
+++ b/packages/core/src/Entry.ts
@@ -1,0 +1,112 @@
+/**
+ * Options for creating an Entry instance
+ */
+export interface EntryProps<IdentifierType, ResultType> {
+  /**
+   * Unique cache identifier
+   */
+  id: IdentifierType;
+
+  /**
+   * Source of where the value was fetched from
+   */
+  source: "local-cache" | "remote-cache" | "worker-fetch";
+
+  /**
+   * Value of the cached entry
+   */
+  value?: ResultType;
+
+  /**
+   * Exception that occurred during fetching of value
+   */
+  error?: Error;
+
+  /**
+   * Amount of time, in milliseconds, until cache entry is stale
+   */
+  ttl?: number;
+
+  /**
+   * Number of milliseconds, after local cache entries expire, data is allowed to be
+   * used while an updated value is fetched in the background
+   */
+  staleCacheThreshold?: number;
+
+  /**
+   * Timestamp of when the *local* cache entry was created
+   */
+  createdAt?: number;
+}
+
+/**
+ * Full cache entry object
+ */
+export class Entry<IdentifierType, ResultType> {
+  /**
+   * Unique cache identifier
+   */
+  public readonly id: IdentifierType;
+
+  /**
+   * Timestamp of when the *local* cache entry was created
+   */
+  public readonly createdAt: number;
+
+  /**
+   * Source of where the value was fetched from
+   */
+  public readonly source: EntryProps<IdentifierType, ResultType>["source"];
+
+  /**
+   * Value of the cached entry
+   */
+  public value?: ResultType;
+
+  /**
+   * Exception that occurred during fetching of value
+   */
+  public error?: Error;
+
+  /**
+   * Timestamp in milliseconds of when the cache entry expires (can still be used as stale if configured)
+   */
+  public expiresAt = 0;
+
+  /**
+   * Timestamp in milliseconds of when the cache entry can no longer be used (passed max stale threshold)
+   */
+  public staleAt = 0;
+
+  /**
+   * Timestamp in millisecond of when the cache
+   */
+  public upsertedAt = 0;
+
+  constructor(entry: EntryProps<IdentifierType, ResultType>) {
+    const now = Date.now();
+
+    this.id = entry.id;
+    this.createdAt = entry.createdAt || Date.now();
+    this.source = entry.source;
+    this.value = entry.value;
+    this.error = entry.error;
+    this.expiresAt = now + (entry.ttl || 0);
+    this.staleAt = this.expiresAt + (entry.staleCacheThreshold || 0);
+    this.upsertedAt = now;
+  }
+
+  /**
+   * Indicates if the entry is stale (can still be used, just past the expiration)
+   */
+  public get isStale(): boolean {
+    return Date.now() > this.expiresAt;
+  }
+
+  /**
+   * Indicates if the entry is still usable (past stale threshold)
+   */
+  public get isExpired(): boolean {
+    return Date.now() > this.staleAt;
+  }
+}

--- a/packages/core/src/Entry.ts
+++ b/packages/core/src/Entry.ts
@@ -69,14 +69,14 @@ export class Entry<IdentifierType, ResultType> {
   public error?: Error;
 
   /**
-   * Timestamp in milliseconds of when the cache entry expires (can still be used as stale if configured)
-   */
-  public expiresAt = 0;
-
-  /**
-   * Timestamp in milliseconds of when the cache entry can no longer be used (passed max stale threshold)
+   * Timestamp in milliseconds of when the cache entry becomes stale (can still be used, just refreshed in the background)
    */
   public staleAt = 0;
+
+  /**
+   * Timestamp in milliseconds of when the cache entry expires (can no longer be used)
+   */
+  public expiresAt = 0;
 
   /**
    * Timestamp in millisecond of when the cache
@@ -91,22 +91,23 @@ export class Entry<IdentifierType, ResultType> {
     this.source = entry.source;
     this.value = entry.value;
     this.error = entry.error;
-    this.expiresAt = now + (entry.ttl || 0);
-    this.staleAt = this.expiresAt + (entry.staleCacheThreshold || 0);
+    this.staleAt = now + (entry.ttl || 0);
+    this.expiresAt = this.staleAt + (entry.staleCacheThreshold || 0);
     this.upsertedAt = now;
   }
 
   /**
-   * Indicates if the entry is stale (can still be used, just past the expiration)
+   * Indicates if the entry is stale (can still be used, just past the ttl)
    */
   public get isStale(): boolean {
-    return Date.now() > this.expiresAt;
+    const now = Date.now();
+    return now > this.staleAt && now <= this.expiresAt;
   }
 
   /**
    * Indicates if the entry is still usable (past stale threshold)
    */
   public get isExpired(): boolean {
-    return Date.now() > this.staleAt;
+    return Date.now() > this.expiresAt;
   }
 }

--- a/packages/core/src/Entry.ts
+++ b/packages/core/src/Entry.ts
@@ -79,7 +79,7 @@ export class Entry<IdentifierType, ResultType> {
   public expiresAt = 0;
 
   /**
-   * Timestamp in millisecond of when the cache
+   * Timestamp in milliseconds of when the cache
    */
   public upsertedAt = 0;
 

--- a/packages/core/src/InternalCacheEntry.ts
+++ b/packages/core/src/InternalCacheEntry.ts
@@ -26,14 +26,14 @@ export class InternalCacheEntry<IdentifierType, ResultType> {
   public staleCacheThreshold = 0;
 
   /**
-   * Timestamp in milliseconds of when the cache entry expires (can still be used as stale if configured)
-   */
-  public expiresAt = 0;
-
-  /**
-   * Timestamp in milliseconds of when the cache entry can no longer be used (passed max stale threshold)
+   * Timestamp in milliseconds of when the cache entry becomes stale (can still be used, just refreshed in the background)
    */
   public staleAt = 0;
+
+  /**
+   * Timestamp in milliseconds of when the cache entry expires (can no longer be used)
+   */
+  public expiresAt = 0;
 
   /**
    * Indicates if cache entry has been accessed while stale
@@ -45,8 +45,8 @@ export class InternalCacheEntry<IdentifierType, ResultType> {
     this.value = entry.value;
     this.ttl = entry.ttl || 0;
     this.staleCacheThreshold = entry.staleCacheThreshold || 0;
-    this.expiresAt = this.entry.expiresAt;
     this.staleAt = this.entry.staleAt;
+    this.expiresAt = this.entry.expiresAt;
   }
 
   /**
@@ -111,8 +111,8 @@ export class InternalCacheEntry<IdentifierType, ResultType> {
 
     this.ttl = ttl;
     this.staleCacheThreshold = staleCacheThreshold;
-    this.expiresAt = this.entry.expiresAt = now + this.ttl;
-    this.staleAt = this.entry.staleAt =
-      now + this.ttl + this.staleCacheThreshold;
+    this.staleAt = this.entry.staleAt = now + this.ttl;
+    this.expiresAt = this.entry.expiresAt =
+      this.staleAt + this.staleCacheThreshold;
   }
 }

--- a/packages/core/src/InternalCacheEntry.ts
+++ b/packages/core/src/InternalCacheEntry.ts
@@ -1,0 +1,133 @@
+import { Entry, EntryProps } from "./Entry";
+
+/**
+ * Enforce required value from the entry props
+ */
+export type InternalCacheEntryProps<IdentifierType, ResultType> = Omit<
+  EntryProps<IdentifierType, ResultType>,
+  "value"
+> & {
+  /**
+   * Value of the cached entry
+   */
+  value: ResultType;
+};
+
+/**
+ * Internal wrapper for the full Entry object, for shortcut management utils
+ */
+export class InternalCacheEntry<IdentifierType, ResultType> {
+  /**
+   * Externally usable cache entry object
+   */
+  public readonly entry: Entry<IdentifierType, ResultType>;
+
+  /**
+   * Value of the cached entry
+   */
+  public value: ResultType;
+
+  /**
+   * Amount of time, in milliseconds, until cache entry is stale
+   */
+  public ttl = 0;
+
+  /**
+   * Number of milliseconds, after local cache entries expire, data is allowed to be
+   * used while an updated value is fetched in the background
+   */
+  public staleCacheThreshold = 0;
+
+  /**
+   * Timestamp in milliseconds of when the cache entry expires (can still be used as stale if configured)
+   */
+  public expiresAt = 0;
+
+  /**
+   * Timestamp in milliseconds of when the cache entry can no longer be used (passed max stale threshold)
+   */
+  public staleAt = 0;
+
+  /**
+   * Indicates if cache entry has been accessed while stale
+   */
+  public staleHit = false;
+
+  public constructor(
+    entry: InternalCacheEntryProps<IdentifierType, ResultType>
+  ) {
+    this.entry = new Entry(entry);
+    this.value = entry.value;
+    this.ttl = entry.ttl || 0;
+    this.staleCacheThreshold = entry.staleCacheThreshold || 0;
+    this.expiresAt = this.entry.expiresAt;
+    this.staleAt = this.entry.staleAt;
+  }
+
+  /**
+   * Unique cache identifier
+   */
+  public get id(): IdentifierType {
+    return this.entry.id;
+  }
+
+  /**
+   * Timestamp of when the *local* cache entry was created
+   */
+  public get createdAt(): number {
+    return this.entry.createdAt;
+  }
+
+  /**
+   * Source of where the value was fetched from
+   */
+  public get source(): EntryProps<IdentifierType, ResultType>["source"] {
+    return this.entry.source;
+  }
+
+  /**
+   * Indicates if the entry is stale (can still be used, just past the expiration)
+   */
+  public get isStale(): boolean {
+    return this.entry.isStale;
+  }
+
+  /**
+   * Indicates if the entry is still usable (past stale threshold)
+   */
+  public get isExpired(): boolean {
+    return this.entry.isExpired;
+  }
+
+  /**
+   * Updates the value and ttls while preserving initiation values
+   *
+   * @param value Value of the cached entry
+   * @param ttl Amount of time, in milliseconds, until cache entry is stale
+   * @param staleCacheThreshold Threshold stale values are allowed to be used
+   */
+  public upsert(
+    value: ResultType,
+    ttl: number,
+    staleCacheThreshold: number
+  ): void {
+    this.touch(ttl, staleCacheThreshold);
+    this.value = this.entry.value = value;
+    this.entry.upsertedAt = Date.now();
+  }
+
+  /**
+   * Extends lifetime of the cache entry
+   * @param ttl Amount of time, in milliseconds, until cache entry is stale
+   * @param staleCacheThreshold Threshold stale values are allowed to be used
+   */
+  public touch(ttl: number, staleCacheThreshold: number): void {
+    const now = Date.now();
+
+    this.ttl = ttl;
+    this.staleCacheThreshold = staleCacheThreshold;
+    this.expiresAt = this.entry.expiresAt = now + this.ttl;
+    this.staleAt = this.entry.staleAt =
+      now + this.ttl + this.staleCacheThreshold;
+  }
+}

--- a/packages/core/src/InternalCacheEntry.ts
+++ b/packages/core/src/InternalCacheEntry.ts
@@ -1,17 +1,4 @@
-import { Entry, EntryProps } from "./Entry";
-
-/**
- * Enforce required value from the entry props
- */
-export type InternalCacheEntryProps<IdentifierType, ResultType> = Omit<
-  EntryProps<IdentifierType, ResultType>,
-  "value"
-> & {
-  /**
-   * Value of the cached entry
-   */
-  value: ResultType;
-};
+import { CachedEntry, CachedEntryProps } from "./CachedEntry";
 
 /**
  * Internal wrapper for the full Entry object, for shortcut management utils
@@ -20,7 +7,7 @@ export class InternalCacheEntry<IdentifierType, ResultType> {
   /**
    * Externally usable cache entry object
    */
-  public readonly entry: Entry<IdentifierType, ResultType>;
+  public readonly entry: CachedEntry<IdentifierType, ResultType>;
 
   /**
    * Value of the cached entry
@@ -53,10 +40,8 @@ export class InternalCacheEntry<IdentifierType, ResultType> {
    */
   public staleHit = false;
 
-  public constructor(
-    entry: InternalCacheEntryProps<IdentifierType, ResultType>
-  ) {
-    this.entry = new Entry(entry);
+  public constructor(entry: CachedEntryProps<IdentifierType, ResultType>) {
+    this.entry = new CachedEntry(entry);
     this.value = entry.value;
     this.ttl = entry.ttl || 0;
     this.staleCacheThreshold = entry.staleCacheThreshold || 0;
@@ -81,7 +66,7 @@ export class InternalCacheEntry<IdentifierType, ResultType> {
   /**
    * Source of where the value was fetched from
    */
-  public get source(): EntryProps<IdentifierType, ResultType>["source"] {
+  public get source(): CachedEntryProps<IdentifierType, ResultType>["source"] {
     return this.entry.source;
   }
 

--- a/packages/core/src/LevelTwo.ts
+++ b/packages/core/src/LevelTwo.ts
@@ -1,5 +1,5 @@
 import EventEmitter from "events";
-import {
+import type {
   CacheSettings,
   DistributedAction,
   MessageBroker,

--- a/packages/core/src/SingleKeyWorker.ts
+++ b/packages/core/src/SingleKeyWorker.ts
@@ -1,5 +1,6 @@
 import EventEmitter from "events";
 import { Worker } from "./Worker";
+import { Entry } from "./Entry";
 
 // Worker specific events
 export interface SingleKeyWorker<ResultType> {
@@ -110,6 +111,16 @@ export class SingleKeyWorker<
    */
   public async getRequired(): Promise<ResultType> {
     return (await this.worker.getRequiredMulti([this.id]))[0];
+  }
+
+  /**
+   * Fetches single entry wrapped value for this single key worker, the "source"
+   * indicates at what point the value was retrieved from (local-cache, remote-cache, or worker)
+   *
+   * Exceptions are returned, not raised, and use the "error" source key
+   */
+  public async getEntry(): Promise<Entry<SingleKeyIdentifierType, ResultType>> {
+    return (await this.worker.getEntryMulti([this.id]))[0];
   }
 
   /**

--- a/packages/core/src/SingleKeyWorker.ts
+++ b/packages/core/src/SingleKeyWorker.ts
@@ -1,6 +1,7 @@
 import EventEmitter from "events";
 import { Worker } from "./Worker";
 import { Entry } from "./Entry";
+import { CachedEntry } from "./CachedEntry";
 
 // Worker specific events
 export interface SingleKeyWorker<ResultType> {
@@ -215,7 +216,7 @@ export class SingleKeyWorker<
   /**
    * Returns local cache entry if it exists, undefined if it does not
    */
-  public peek(): ResultType | undefined {
+  public peek(): CachedEntry<SingleKeyIdentifierType, ResultType> | undefined {
     return this.worker.peek(this.id);
   }
 }

--- a/packages/core/src/Worker.ts
+++ b/packages/core/src/Worker.ts
@@ -983,9 +983,9 @@ export class Worker<
       const entry = this.cache.get(ids[index]);
 
       // Exit if any entry can't be used
-      if (!entry || entry.staleAt < now) {
+      if (!entry || entry.expiresAt < now) {
         return;
-      } else if (entry.expiresAt < now) {
+      } else if (entry.staleAt < now) {
         entry.staleHit = true;
       }
 

--- a/packages/core/src/WorkerError.ts
+++ b/packages/core/src/WorkerError.ts
@@ -1,0 +1,16 @@
+import { Entry, EntryProps } from "./Entry";
+
+/**
+ * Wrapper to pass entry source along with an error
+ */
+export class WorkerError<IdentifierType, ResultType> extends Error {
+  /**
+   * Entry source for the error
+   */
+  public readonly entry: Entry<IdentifierType, ResultType>;
+
+  constructor(entry: EntryProps<IdentifierType, ResultType>) {
+    super(entry.error?.message || "Unknown Worker Error");
+    this.entry = new Entry<IdentifierType, ResultType>(entry);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,4 @@ export * from "./Worker";
 export * from "./SingleKeyWorker";
 export * from "./constants";
 export * from "./interfaces";
+export * from "./Entry";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from "./SingleKeyWorker";
 export * from "./constants";
 export * from "./interfaces";
 export * from "./Entry";
+export * from "./CachedEntry";

--- a/packages/core/test/CachedEntry.test.ts
+++ b/packages/core/test/CachedEntry.test.ts
@@ -1,0 +1,14 @@
+import { CachedEntry } from "../src/CachedEntry";
+
+describe("CachedEntry", () => {
+  test("should enforce value to be required", () => {
+    const entry = new CachedEntry({
+      id: "abc123",
+      source: "local-cache",
+      ttl: 30,
+      staleCacheThreshold: 100,
+      value: "foobar123",
+    });
+    expect(entry.value).toStrictEqual("foobar123");
+  });
+});

--- a/packages/core/test/Entry.test.ts
+++ b/packages/core/test/Entry.test.ts
@@ -1,0 +1,35 @@
+import { Entry } from "../src/Entry";
+import { wait } from "./utils";
+
+describe("Entry", () => {
+  test("isStale should indicate entry is still usable, but should be refreshed", async () => {
+    const entry = new Entry({
+      id: "abc123",
+      source: "local-cache",
+      ttl: 30,
+      staleCacheThreshold: 100,
+    });
+    expect(entry.isStale).toStrictEqual(false);
+
+    await wait(50);
+    expect(entry.isStale).toStrictEqual(true);
+  });
+
+  test("isExpired should indicate entry is fully expired, past stale threshold", async () => {
+    const entry = new Entry({
+      id: "abc123",
+      source: "local-cache",
+      ttl: 30,
+      staleCacheThreshold: 100,
+    });
+    expect(entry.isExpired).toStrictEqual(false);
+
+    // Should still be usable after stale threshold
+    await wait(50);
+    expect(entry.isStale).toStrictEqual(true);
+    expect(entry.isExpired).toStrictEqual(false);
+
+    await wait(150);
+    expect(entry.isExpired).toStrictEqual(true);
+  });
+});

--- a/packages/core/test/InternalCacheEntry.test.ts
+++ b/packages/core/test/InternalCacheEntry.test.ts
@@ -1,0 +1,48 @@
+import { InternalCacheEntry } from "../src/InternalCacheEntry";
+
+describe("InternalCacheEntry", () => {
+  test("getters should map to the entry properties", () => {
+    const entry = new InternalCacheEntry({
+      id: "abc123",
+      source: "local-cache",
+      value: "val123",
+    });
+    expect(entry.id).toStrictEqual(entry.entry.id);
+    expect(entry.createdAt).toStrictEqual(entry.entry.createdAt);
+    expect(entry.source).toStrictEqual(entry.entry.source);
+    expect(entry.isStale).toStrictEqual(entry.entry.isStale);
+    expect(entry.isExpired).toStrictEqual(entry.entry.isExpired);
+  });
+
+  test("upsert should extend the ttl and update the value", () => {
+    const entry = new InternalCacheEntry({
+      id: "abc123",
+      source: "local-cache",
+      value: "val123",
+      ttl: 50,
+    });
+
+    const touchSpy = jest.spyOn(entry, "touch");
+
+    entry.upsert("val654", 100, 500);
+    expect(touchSpy).toHaveBeenCalledTimes(1);
+    expect(touchSpy).toHaveBeenLastCalledWith(100, 500);
+    expect(entry.value).toStrictEqual("val654");
+  });
+
+  test("touch should extend the ttl", () => {
+    const entry = new InternalCacheEntry({
+      id: "abc123",
+      source: "local-cache",
+      value: "val123",
+      ttl: 50,
+      staleCacheThreshold: 75,
+    });
+    expect(entry.ttl).toStrictEqual(50);
+    expect(entry.staleCacheThreshold).toStrictEqual(75);
+
+    entry.touch(100, 150);
+    expect(entry.ttl).toStrictEqual(100);
+    expect(entry.staleCacheThreshold).toStrictEqual(150);
+  });
+});

--- a/packages/core/test/InternalCacheEntry.test.ts
+++ b/packages/core/test/InternalCacheEntry.test.ts
@@ -6,6 +6,7 @@ describe("InternalCacheEntry", () => {
       id: "abc123",
       source: "local-cache",
       value: "val123",
+      ttl: 5000,
     });
     expect(entry.id).toStrictEqual(entry.entry.id);
     expect(entry.createdAt).toStrictEqual(entry.entry.createdAt);

--- a/packages/core/test/SingleKeyWorker.test.ts
+++ b/packages/core/test/SingleKeyWorker.test.ts
@@ -1,4 +1,4 @@
-import { LevelTwo, SingleKeyWorker } from "../src";
+import { Entry, LevelTwo, SingleKeyWorker } from "../src";
 import {
   getMockedMessageBroker,
   getMockedRemoteCache,
@@ -96,6 +96,32 @@ describe("SingleKeyWorker", () => {
       npm: "xyz456",
     });
     expect(await worker.getRequired()).toEqual({
+      github: "abc123",
+      npm: "xyz456",
+    });
+    expect(remoteCache.get).toHaveBeenCalledTimes(2);
+    expect(fetchProcess).toHaveBeenCalledTimes(2);
+  });
+
+  test("getEntry should return entry wrapped value", async () => {
+    fetchProcess.mockResolvedValue(undefined);
+
+    let entry = await worker.getEntry();
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.id).toStrictEqual("tokens");
+    expect(entry.value).toBeUndefined();
+    expect(remoteCache.get).toHaveBeenCalledTimes(1);
+    expect(fetchProcess).toHaveBeenCalledTimes(1);
+
+    // Confirm call is successful when there is a value
+    fetchProcess.mockResolvedValue({
+      github: "abc123",
+      npm: "xyz456",
+    });
+    entry = await worker.getEntry();
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.id).toStrictEqual("tokens");
+    expect(entry.value).toEqual({
       github: "abc123",
       npm: "xyz456",
     });

--- a/packages/core/test/utils/MockRemoteCache.ts
+++ b/packages/core/test/utils/MockRemoteCache.ts
@@ -56,11 +56,17 @@ export class MockRemoteCache implements RemoteCache {
     if (this.streamResponses) {
       for (const id of ids) {
         await wait();
-        earlyWrite(id, this.cache[`${worker}:${id}`]?.value);
+        if (this.cache[`${worker}:${id}`]?.expires > Date.now()) {
+          earlyWrite(id, this.cache[`${worker}:${id}`]?.value);
+        }
       }
     } else {
       await wait();
-      return ids.map((id) => this.cache[id]?.value);
+      return ids.map((id) => {
+        if (this.cache[`${worker}:${id}`]?.expires > Date.now()) {
+          return this.cache[`${worker}:${id}`]?.value;
+        }
+      });
     }
   }
 


### PR DESCRIPTION
- `getEntry`: Fetching meta information along with a cached value
- `getEntryMulti`: Fetching meta information along with cached values

### Breaking Change

Iterable, `peek`, `peekMulti`, `values`, `entries`, `forEach` all return `CachedEntry` wrapped result values instead of the `ResultValue` directly.

Switching to a wrapped `CachedEntry` will allow for current and future expansion on utilities for metric tracking of entries.